### PR TITLE
Use `,` (instead of the incorrect `;`) to separate multiple key-value pairs in meta@content.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <title>JavaScript console - for debugging JavaScript and remote debugging mobile web apps</title>
-<meta id="meta" name="viewport" content="width=device-width; user-scalable=no; initial-scale=1.0" />
+<meta id="meta" name="viewport" content="width=device-width, user-scalable=no, initial-scale=1" />
 <!-- 
 
  Hey there fellow JavaScript lover - I assume you've got a soft spot
@@ -50,9 +50,6 @@
 <script src="prettify.packed.js"></script>
 <script src="EventSource.js"></script>
 <script src="console.js"></script>
-<script>var _gaq=[['_setAccount','UA-1656750-21'],['_trackPageview']];(function(d,t){
-var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
-g.async=1;g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)
-})(document,'script')</script>
+<script>var _gaq=[['_setAccount','UA-1656750-21'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)})(document,'script')</script>
 </body>
 </html>


### PR DESCRIPTION
Use `,` (instead of the incorrect `;`) to separate multiple key-value pairs in meta@content.
