### PR TITLE
Fix for using jsconsole in iframes

### DIFF
--- a/remote.html
+++ b/remote.html
@@ -28,7 +28,7 @@ window.addEventListener('message', function (event) {
 setTimeout(function () {
   var sse = new EventSource('/remote/' + id + '/run');
   sse.onmessage = function (event) {
-    window.top.postMessage(event.data, origin);
+    window.parent.postMessage(event.data, origin);
   };
 }, 13);
 </script>


### PR DESCRIPTION
When remote.html is injected into an iframe, `window.top` is not the same window it was injected into. The effect of this is that jsconsole attempts to postmessage the wrong window, which limits jsconsole to working only in one direction (client -> jsconsole). Using `window.parent` instead of `window.top` allows jsconsole to postmessage the correct window, restoring the full jsconsole functionality.
