### PR TITLE
Fix viewport value list

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -28,7 +28,7 @@
     doc = iframe.contentDocument || iframe.contentWindow.document;
 
     doc.open();
-    doc.write('<!DOCTYPE html><html id="jsconsole"><head><title>jsconsole</title><meta id="meta" name="viewport" content="width=device-width; height=device-height; user-scalable=no; initial-scale=1.0" /><link rel="stylesheet" href="http://jsconsole.com/console.css" type="text/css" /></head><body><form><textarea autofocus id="exec" spellcheck="false" autocapitalize="off" autofocus rows="1"></textarea></form><div id="console"><ul id="output"></ul></div><div id="footer"><a href="http://github.com/remy/jsconsole">Fork on Github</a> &bull; <a href="http://twitter.com/rem">Built by @rem</a></div><script src="http://jsconsole.com/prettify.js"></script><script src="http://jsconsole.com/console.js?' + Math.random() + '"></script></body></html>');
+    doc.write('<!DOCTYPE html><html id="jsconsole"><head><title>jsconsole</title><meta id="meta" name="viewport" content="width=device-width, height=device-height, user-scalable=no, initial-scale=1.0" /><link rel="stylesheet" href="http://jsconsole.com/console.css" type="text/css" /></head><body><form><textarea autofocus id="exec" spellcheck="false" autocapitalize="off" autofocus rows="1"></textarea></form><div id="console"><ul id="output"></ul></div><div id="footer"><a href="http://github.com/remy/jsconsole">Fork on Github</a> &bull; <a href="http://twitter.com/rem">Built by @rem</a></div><script src="http://jsconsole.com/prettify.js"></script><script src="http://jsconsole.com/console.js?' + Math.random() + '"></script></body></html>');
     doc.close();
     
     iframe.contentWindow.onload = function () {


### PR DESCRIPTION
From the Chrome error log:

> Viewport argument value "device-width;" for key "width" is invalid, and has been ignored. Note that ';' is not a separator in viewport values. The list should be comma-separated.
> Viewport argument value "device-height;" for key "height" is invalid, and has been ignored. Note that ';' is not a separator in viewport values. The list should be comma-separated.
> Viewport argument value "no;" for key "user-scalable" is invalid, and has been ignored. Note that ';' is not a separator in viewport values. The list should be comma-separated
