### PR TITLE
remove hardcoded http protocol, thereby supporting https

### DIFF
--- a/remote.js
+++ b/remote.js
@@ -87,7 +87,7 @@ var last = getRemoteScript();
 
 var lastSrc = last.getAttribute('src'),
     id = lastSrc.replace(/.*\?/, ''),
-    origin = 'http://' + lastSrc.substr(7).replace(/\/.*$/, ''),
+    origin = lastSrc.replace(/\/remote.js.*/, ''),
     remoteWindow = null,
     queue = [],
     msgType = '';


### PR DESCRIPTION
tested in a local https-only environment - works.
it seems to be the only thing holding <script src="https://jsconsole.com/remote.js?..."> back.