### PR TITLE
fix for origin errors

### DIFF
--- a/remote.js
+++ b/remote.js
@@ -87,7 +87,7 @@ var last = getRemoteScript();
 
 var lastSrc = last.getAttribute('src'),
     id = lastSrc.replace(/.*\?/, ''),
-    origin = 'http://' + lastSrc.substr(7).replace(/\/.*$/, ''),
+    origin = document.location.protocol + '//' + lastSrc.substr(7).replace(/\/.*$/, ''),
     remoteWindow = null,
     queue = [],
     msgType = '';


### PR DESCRIPTION
It happens a lot of times after the new SPDY protocol checks started coming out, https connections which don't allow http requests etc. This solves it.