### PR TITLE
fix remote script origin

### DIFF
--- a/public/js/remote.js
+++ b/public/js/remote.js
@@ -79,7 +79,7 @@ var last = getRemoteScript();
 
 var lastSrc = last.getAttribute('src'),
     id = lastSrc.replace(/.*\?/, ''),
-    origin = document.location.protocol + '//' + lastSrc.substr(7).replace(/\/.*$/, ''),
+    origin = document.location.protocol + '//' + lastSrc.substr(lastSrc.search('//')+2).replace(/\/.*$/, ''),
     remoteWindow = null,
     queue = [],
     msgType = '';


### PR DESCRIPTION
Instead of a fix substring at 7 we are looking for '//' which also works
if the script is inserted using https (e.g.
'https://domain.tld/js/remote.js/...') or dynamic protocol (e.g.
'//domain.tld/js/remote.js/...').
