### PR TITLE
Allow debugging for local apps

### DIFF
--- a/public/js/remote.js
+++ b/public/js/remote.js
@@ -79,7 +79,9 @@ var last = getRemoteScript();
 
 var lastSrc = last.getAttribute('src'),
     id = lastSrc.replace(/.*\?/, ''),
-    origin = document.location.protocol + '//' + lastSrc.substr(7).replace(/\/.*$/, ''),
+    // in PhoneGap apps default protocol HTTP is used
+    protocol = (document.location.protocol == 'file:') ? 'http:' : document.location.protocol,
+    origin = protocol + '//' + lastSrc.substr(7).replace(/\/.*$/, ''),
     remoteWindow = null,
     queue = [],
     msgType = '';


### PR DESCRIPTION
Protocol might be local. In theses cases default port HTTP will be used. For details, have a look at PR https://github.com/remy/jsconsole/pull/67, which introduces unwanted behaviour for PhoneGap apps.
