### PR TITLE
Fix origin for https://jsconsole.com and other https hosts

### DIFF
--- a/public/js/remote.js
+++ b/public/js/remote.js
@@ -79,7 +79,8 @@ var last = getRemoteScript();
 
 var lastSrc = last.getAttribute('src'),
     id = lastSrc.replace(/.*\?/, ''),
-    origin = document.location.protocol + '//' + lastSrc.substr(7).replace(/\/.*$/, ''),
+    protocol = /https?:\/\//.exec(lastSrc)[0],
+    origin = protocol + lastSrc.substr(protocol.length).replace(/\/.*$/, ''),
     remoteWindow = null,
     queue = [],
     msgType = '';


### PR DESCRIPTION
Now jsconsole.com will only load over https the `substr(7)` only matched `https:/` leaving `/jsconsole.com...` resulting in the iframe pointing at `http:///remote.html`

This fix uses the protocol of `lastsrc` rather than the current document, and works on both http and https