### PR TITLE
Use HTTPS Everywhere

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2010 Remy Sharp, http://jsconsole.com
+Copyright (c) 2010 Remy Sharp, https://jsconsole.com
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A JavaScript web console, useful for quick experimentation, debugging, presentat
 
 # Features
 
-- Remote device debugging using "listen" command ([more info](http://jsconsole.com/remote-debugging.html))
+- Remote device debugging using "listen" command ([more info](https://jsconsole.com/remote-debugging.html))
 - Resizable font (yep, biggest issue with Firebug in workshops)
 - Autocomplete in WebKit desktop browsers
 - Shift + up/down for bigger console
@@ -14,7 +14,7 @@ A JavaScript web console, useful for quick experimentation, debugging, presentat
 
 # Hosting jsconsole yourself
 
-This requires that you install [node.js](http://nodejs.org). Once installed, download this project (or clone it using git) and inside the new `jsconsole` directory run:
+This requires that you install [node.js](https://nodejs.org). Once installed, download this project (or clone it using git) and inside the new `jsconsole` directory run:
 
     npm install
 
@@ -30,4 +30,4 @@ Or to run on a specific port (like 8080):
 
 Then check your own ip address of the machine it's running on (using `ipconfig` for windows or `ifconfig` for mac and linux). Then on the mobile phone, just visit that IP address and port you're running jsconsole on:
 
-![jsconsole running locally](http://i.imgur.com/hyRF5.png)
+![jsconsole running locally](https://i.imgur.com/hyRF5.png)

--- a/public/index.html
+++ b/public/index.html
@@ -26,10 +26,10 @@
  DOMWindow object.
 
  There's more I want to do with this, so watch the github account
- or even contribute: http://github.com/remy/jsconsole
+ or even contribute: https://github.com/remy/jsconsole
 
  Otherwise, hope you enjoy this app. Any questions or issues, drop
- me a message on github or Twitter: http://twitter.com/rem
+ me a message on github or Twitter: https://twitter.com/rem
 
  - Cheers, @rem
 
@@ -59,7 +59,7 @@
 <div id="console">
   <ul id="output"></ul>
 </div>
-<div id="footer"><a href="#">Install app</a> &bull; <a href="http://github.com/remy/jsconsole">Fork on Github</a> &bull; <a href="http://twitter.com/rem">Built by @rem</a></div>
+<div id="footer"><a href="#">Install app</a> &bull; <a href="https://github.com/remy/jsconsole">Fork on Github</a> &bull; <a href="https://twitter.com/rem">Built by @rem</a></div>
 <script src="/js/prettify.packed.js"></script>
 <script src="/js/EventSource.js"></script>
 <script src="/js/copy.js"></script>

--- a/public/inject.html
+++ b/public/inject.html
@@ -7,12 +7,12 @@
 <style>* { font-family: sans-serif; }</style>
 <script>
 if (!window.location.search) {
-  window.location = "?javascript:(function(s){s.src='http://jsconsole.com/js/inject.js';document.body.appendChild(s)})(document.createElement('script'))";
+  window.location = "?javascript:(function(s){s.src='https://jsconsole.com/js/inject.js';document.body.appendChild(s)})(document.createElement('script'))";
 }
 </script>
 </head>
 <body>
-<p>This page should redirect right away to the correct url, once it does, bookmarket it on your mobile phone, then remove the <em>http://jsconsole.com/inject.html?</em> (including the question mark) part to get the bookmarklet to work.</p>
-<p>Alternatively, to inject JS Console, bookmarket this: <a href="javascript:(function(s){s.src='http://jsconsole.com/js/inject.js';document.body.appendChild(s)})(document.createElement('script'))">JS Console</a> and sync to your phone.</p>
+<p>This page should redirect right away to the correct url, once it does, bookmarket it on your mobile phone, then remove the <em>https://jsconsole.com/inject.html?</em> (including the question mark) part to get the bookmarklet to work.</p>
+<p>Alternatively, to inject JS Console, bookmarket this: <a href="javascript:(function(s){s.src='https://jsconsole.com/js/inject.js';document.body.appendChild(s)})(document.createElement('script'))">JS Console</a> and sync to your phone.</p>
 </body>
 </html>

--- a/public/js/console.js
+++ b/public/js/console.js
@@ -348,7 +348,7 @@ function loadDOM(url) {
       script = document.createElement('script'),
       cb = 'loadDOM' + +new Date;
 
-  script.src = 'http://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20html%20where%20url%3D%22' + encodeURIComponent(url) + '%22&format=xml&callback=' + cb;
+  script.src = 'https://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20html%20where%20url%3D%22' + encodeURIComponent(url) + '%22&format=xml&callback=' + cb;
 
   window[cb] = function (yql) {
     if (yql.results.length) {
@@ -601,7 +601,7 @@ function setHistory(history) {
 }
 
 function about() {
-  return 'Built by <a target="_blank" href="http://twitter.com/rem">@rem</a> • <a target="_blank" href="https://github.com/remy/jsconsole">open source</a>';
+  return 'Built by <a target="_blank" href="https://twitter.com/rem">@rem</a> • <a target="_blank" href="https://github.com/remy/jsconsole">open source</a>';
 }
 
 
@@ -632,15 +632,15 @@ var exec = document.getElementById('exec'),
     pos = 0,
     libraries = {
         jquery: 'https://code.jquery.com/jquery.min.js',
-        prototype: 'http://ajax.googleapis.com/ajax/libs/prototype/1/prototype.js',
-        dojo: 'http://ajax.googleapis.com/ajax/libs/dojo/1/dojo/dojo.xd.js',
-        mootools: 'http://ajax.googleapis.com/ajax/libs/mootools/1/mootools-yui-compressed.js',
+        prototype: 'https://ajax.googleapis.com/ajax/libs/prototype/1/prototype.js',
+        dojo: 'https://ajax.googleapis.com/ajax/libs/dojo/1/dojo/dojo.xd.js',
+        mootools: 'https://ajax.googleapis.com/ajax/libs/mootools/1/mootools-yui-compressed.js',
         underscore: 'https://cdn.jsdelivr.net/underscorejs/latest/underscore-min.js',
         lodash: 'https://cdn.jsdelivr.net/lodash/latest/lodash.min.js',
         moment: 'https://cdn.jsdelivr.net/momentjs/latest/moment.min.js',
         rightjs: 'http://rightjs.org/hotlink/right.js',
         coffeescript: 'https://cdn.jsdelivr.net/coffeescript/latest/coffee-script.min.js',
-        yui: 'http://yui.yahooapis.com/3.2.0/build/yui/yui-min.js'
+        yui: 'https://yui.yahooapis.com/3.2.0/build/yui/yui-min.js'
     },
     body = document.getElementsByTagName('body')[0],
     logAfter = null,

--- a/public/js/console.js
+++ b/public/js/console.js
@@ -331,7 +331,7 @@ function loadScript() {
       var script = document.createElement('script');
       script.src = url
       script.onload = function () {
-        window.top.info('Loaded ' + url, 'http://' + window.location.hostname);
+        window.top.info('Loaded ' + url);
         if (url == libraries.coffeescript) window.top.info('Now you can type CoffeeScript instead of plain old JS!');
       };
       script.onerror = function () {

--- a/public/js/inject.js
+++ b/public/js/inject.js
@@ -28,7 +28,7 @@
     doc = iframe.contentDocument || iframe.contentWindow.document;
 
     doc.open();
-    doc.write('<!DOCTYPE html><html id="jsconsole"><head><title>jsconsole</title><meta id="meta" name="viewport" content="width=device-width; height=device-height; user-scalable=no; initial-scale=1.0" /><link rel="stylesheet" href="http://jsconsole.com/console.css" type="text/css" /></head><body><form><textarea autofocus id="exec" spellcheck="false" autocapitalize="off" autofocus rows="1"></textarea></form><div id="console"><ul id="output"></ul></div><div id="footer"><a href="http://github.com/remy/jsconsole">Fork on Github</a> &bull; <a href="http://twitter.com/rem">Built by @rem</a></div><script src="http://jsconsole.com/prettify.js"></script><script src="http://jsconsole.com/console.js?' + Math.random() + '"></script></body></html>');
+    doc.write('<!DOCTYPE html><html id="jsconsole"><head><title>jsconsole</title><meta id="meta" name="viewport" content="width=device-width; height=device-height; user-scalable=no; initial-scale=1.0" /><link rel="stylesheet" href="https://jsconsole.com/console.css" type="text/css" /></head><body><form><textarea autofocus id="exec" spellcheck="false" autocapitalize="off" autofocus rows="1"></textarea></form><div id="console"><ul id="output"></ul></div><div id="footer"><a href="https://github.com/remy/jsconsole">Fork on Github</a> &bull; <a href="https://twitter.com/rem">Built by @rem</a></div><script src="https://jsconsole.com/prettify.js"></script><script src="https://jsconsole.com/console.js?' + Math.random() + '"></script></body></html>');
     doc.close();
     
     iframe.contentWindow.onload = function () {

--- a/public/js/prettify.packed.js
+++ b/public/js/prettify.packed.js
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//      https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/public/remote-debugging.html
+++ b/public/remote-debugging.html
@@ -54,7 +54,7 @@
 <p>To create a new session, in the jsconsole prompt, <a target="_blank" href="/?:listen">simply run</a>:</p>
 <pre><code>:listen</code></pre>
 <p>This will yield a unique key along the lines of <code>FAE031CD-74A0-46D3-AE36-757BAB262BEA</code>. Now using this unique key, include a <code>&lt;script&gt;</code> anywhere in the web app that you wish to debug:</p>
-<pre><code>&lt;script src=&quot;http://jsconsole.com/remote.js?FAE031CD-74A0-46D3-AE36-757BAB262BEA&quot;&gt;&lt;/script&gt;</code></pre>
+<pre><code>&lt;script src=&quot;https://jsconsole.com/remote.js?FAE031CD-74A0-46D3-AE36-757BAB262BEA&quot;&gt;&lt;/script&gt;</code></pre>
 
 <p>Now any calls to <code>console.log</code> from your web app will display the result in the jsconsole session that is listening to your key. Equally, if you run a command in the jsconsole session, the code will injected in to your web app and the result returned to jsconsole.</p>
 


### PR DESCRIPTION
Since http://jsconsole.com 301s to https://jsconsole.com, links throughout might as well use the latter. I also adjusted other instances of `http://` where `https://` works.