### PR TITLE
Fix viewport value list

### DIFF
--- a/public/js/inject.js
+++ b/public/js/inject.js
@@ -1,6 +1,6 @@
 (function (window, document) {
   var iframe, doc;
-  
+
   window.JSCONSOLE = {
     contentWindow: window,
     contentDocument: document,
@@ -28,9 +28,9 @@
     doc = iframe.contentDocument || iframe.contentWindow.document;
 
     doc.open();
-    doc.write('<!DOCTYPE html><html id="jsconsole"><head><title>jsconsole</title><meta id="meta" name="viewport" content="width=device-width; height=device-height; user-scalable=no; initial-scale=1.0" /><link rel="stylesheet" href="https://jsconsole.com/console.css" type="text/css" /></head><body><form><textarea autofocus id="exec" spellcheck="false" autocapitalize="off" autofocus rows="1"></textarea></form><div id="console"><ul id="output"></ul></div><div id="footer"><a href="https://github.com/remy/jsconsole">Fork on Github</a> &bull; <a href="https://twitter.com/rem">Built by @rem</a></div><script src="https://jsconsole.com/prettify.js"></script><script src="https://jsconsole.com/console.js?' + Math.random() + '"></script></body></html>');
+    doc.write('<!DOCTYPE html><html id="jsconsole"><head><title>jsconsole</title><meta id="meta" name="viewport" content="width=device-width, height=device-height, user-scalable=no, initial-scale=1.0" /><link rel="stylesheet" href="https://jsconsole.com/console.css" type="text/css" /></head><body><form><textarea autofocus id="exec" spellcheck="false" autocapitalize="off" autofocus rows="1"></textarea></form><div id="console"><ul id="output"></ul></div><div id="footer"><a href="https://github.com/remy/jsconsole">Fork on Github</a> &bull; <a href="https://twitter.com/rem">Built by @rem</a></div><script src="https://jsconsole.com/prettify.js"></script><script src="https://jsconsole.com/console.js?' + Math.random() + '"></script></body></html>');
     doc.close();
-    
+
     iframe.contentWindow.onload = function () {
       this.document.getElementById('exec').focus();
     };


### PR DESCRIPTION
From the Chrome error log:

> Viewport argument value "device-width;" for key "width" is invalid, and has been ignored. Note that ';' is not a separator in viewport values. The list should be comma-separated.
> Viewport argument value "device-height;" for key "height" is invalid, and has been ignored. Note that ';' is not a separator in viewport values. The list should be comma-separated.
> Viewport argument value "no;" for key "user-scalable" is invalid, and has been ignored. Note that ';' is not a separator in viewport values. The list should be comma-separated

---

Originally filed as #44, PR rebased and reopened.