### PR TITLE
feat: Allow importing any npm library via :load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6434,6 +6434,11 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
+    "is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+    },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-dom": "^15.6.1",
     "babylon-walk": "^1.0.2",
     "babylon": "^6.18.0",
+    "is-url": "^1.2.4",
     "lodash": "^4.17.4",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",

--- a/src/core/lib/internal-commands.js
+++ b/src/core/lib/internal-commands.js
@@ -37,7 +37,7 @@ const about = () => ({
 const load = async ({ args: urls, console }) => {
   const document = getContainer().contentDocument;
   urls.forEach(url => {
-    if (url === "datefns") url = "date-fns" // Backwards compatibility
+    if (url === "datefns") url = "date-fns"; // Backwards compatibility
     url = isUrl(url) ? url : `https://cdn.jsdelivr.net/npm/${url}`;
     const script = document.createElement('script');
     script.src = url;

--- a/src/core/lib/internal-commands.js
+++ b/src/core/lib/internal-commands.js
@@ -37,6 +37,7 @@ const about = () => ({
 const load = async ({ args: urls, console }) => {
   const document = getContainer().contentDocument;
   urls.forEach(url => {
+    if (url === "datefns") url = "date-fns" // Backwards compatibility
     url = isUrl(url) ? url : `https://cdn.jsdelivr.net/npm/${url}`;
     const script = document.createElement('script');
     script.src = url;

--- a/src/core/lib/internal-commands.js
+++ b/src/core/lib/internal-commands.js
@@ -1,5 +1,6 @@
 /*global window EventSource fetch */
 import { getContainer } from './run';
+import isUrl from 'is-url';
 
 const version = process.env.REACT_APP_VERSION;
 const API = process.env.REACT_APP_API || '';
@@ -16,8 +17,7 @@ version: ${version}`,
 const help = () => ({
   value: `:listen [id] - starts remote debugging session
 :theme dark|light
-:load &lt;script_url&gt; load also supports shortcuts, like \`:load jquery\`
-:libraries
+:load &lt;script_url&gt; load also supports shortcuts to the default file of any npm package, like \`:load jquery\`
 :clear
 :history
 :about
@@ -34,18 +34,10 @@ const about = () => ({
   html: true,
 });
 
-const libs = {
-  jquery: 'https://code.jquery.com/jquery.min.js',
-  underscore: 'https://cdn.jsdelivr.net/underscorejs/latest/underscore-min.js',
-  lodash: 'https://cdn.jsdelivr.net/lodash/latest/lodash.min.js',
-  moment: 'https://cdn.jsdelivr.net/momentjs/latest/moment.min.js',
-  datefns: 'https://cdn.jsdelivr.net/gh/date-fns/date-fns/dist/date_fns.min.js',
-};
-
 const load = async ({ args: urls, console }) => {
   const document = getContainer().contentDocument;
   urls.forEach(url => {
-    url = libs[url] || url;
+    url = isUrl(url) ? url : `https://cdn.jsdelivr.net/npm/${url}`;
     const script = document.createElement('script');
     script.src = url;
     script.onload = () => console.log(`Loaded ${url}`);
@@ -53,15 +45,6 @@ const load = async ({ args: urls, console }) => {
     document.body.appendChild(script);
   });
   return 'Loading script…';
-};
-
-const libraries = () => {
-  return {
-    value: Object.keys(libs)
-      .map(name => `<strong>${name}</strong>: ${libs[name]}`)
-      .join('\n'),
-    html: true,
-  };
 };
 
 const set = async ({ args: [key, value], app }) => {
@@ -155,7 +138,6 @@ const listen = async ({ args: [id], console: internalConsole }) => {
 };
 
 const commands = {
-  libraries,
   help,
   about,
   load,


### PR DESCRIPTION
This PR allows the `:load` command to be used to load any npm package through JSDelivr, not just the select few previously.

Previously, the code checked if the provided parameter was part of the 5 supported libraries.
Now, it checks if the parameter is a URL and if not, assumes it is an npm package and loads it from `https://cdn.jsdelivr.net/npm/${PACKAGE_NAME}`.

This change should be seamless except for `datefns` where the npm package has a dash between the two words.