### PR TITLE
call preventDefault on 'Ctrl+L'

### DIFF
--- a/src/core/components/Input.js
+++ b/src/core/components/Input.js
@@ -39,7 +39,8 @@ class Input extends Component {
 
     if (e.ctrlKey && code === 'l') {
       this.props.onClear();
-      return;
+      e.preventDefault();
+      return false;
     }
 
     if (!multiline) {


### PR DESCRIPTION
call preventDefault to disable the default action of 'Ctrl+L' which is focusing address bar.